### PR TITLE
Gnome Shell 40 Support

### DIFF
--- a/lockscreen@sri.ramkrishna.me/extension.js
+++ b/lockscreen@sri.ramkrishna.me/extension.js
@@ -23,7 +23,7 @@
  * Simple extension to lock the screen from an icon on the panel.
  */
 
-const {St, Clutter, Gio, Shell} = imports.gi;
+const {St, Clutter} = imports.gi;
 
 /*const ScreenSaver = imports.misc.screenSaver;*/
 const Main = imports.ui.main;

--- a/lockscreen@sri.ramkrishna.me/extension.js
+++ b/lockscreen@sri.ramkrishna.me/extension.js
@@ -23,10 +23,7 @@
  * Simple extension to lock the screen from an icon on the panel.
  */
 
-const Gio = imports.gi.Gio;
-const Lang = imports.lang;
-const Shell = imports.gi.Shell;
-const St = imports.gi.St;
+const {St, Clutter, Gio, Shell} = imports.gi;
 
 /*const ScreenSaver = imports.misc.screenSaver;*/
 const Main = imports.ui.main;
@@ -37,8 +34,7 @@ function init() {
 	_lockScreenButton = new St.Bin({ style_class: 'panel-button', 
 								reactive: true,
 								can_focus: true,
-								x_fill: true,
-								y_fill: false,
+								y_align: Clutter.ActorAlign.CENTER,
 								track_hover: true });
 	let icon = new St.Icon ({ icon_name: 'changes-prevent-symbolic',
 								style_class: 'system-status-icon'});

--- a/lockscreen@sri.ramkrishna.me/metadata.json
+++ b/lockscreen@sri.ramkrishna.me/metadata.json
@@ -2,9 +2,9 @@
   "description": "Add lock icon to the panel and lock the screen instead of using ctrl-alt-l", 
   "name": "Lock Screen", 
   "shell-version": [
-    "3.10", "3.12", "3.14", "3.16", "3.18", "3.20"
+    "3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "40.0"
   ], 
   "url": "https://github.com/sramkrishna/gnome3-extensions", 
   "uuid": "lockscreen@sri.ramkrishna.me", 
-  "version": 1
+  "version": 13
 }

--- a/lockscreen@sri.ramkrishna.me/stylesheet.css
+++ b/lockscreen@sri.ramkrishna.me/stylesheet.css
@@ -1,1 +1,0 @@
-/* none used*/


### PR DESCRIPTION
**stylesheet.css**

Removed `stylesheet.css` file. This extension doesn't need stylesheet.css, since this file is not mandatory for GNOME Shell extensions and it is an unused file.

**extension.js**

- Removed unused Lang, Shell and Gio imports.
- Organized ui imports.
- `y_align` may seems unnecessary but it is needed for some GNOME Shell themes.
- Removed `x_fill` and `y_fill` since these properties has been removed on GNOME Shell 40.

**metadata.json**

- Bumped version to 13 since the latest version on GNOME Shell extensions website is 12.
- Added GNOME Shell 40.0 support.