### PR TITLE
New GNOME Shell version checking

### DIFF
--- a/lockscreen@sri.ramkrishna.me/metadata.json
+++ b/lockscreen@sri.ramkrishna.me/metadata.json
@@ -2,7 +2,7 @@
   "description": "Add lock icon to the panel and lock the screen instead of using ctrl-alt-l", 
   "name": "Lock Screen", 
   "shell-version": [
-    "3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "40.0"
+    "3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "40"
   ], 
   "url": "https://github.com/sramkrishna/gnome3-extensions", 
   "uuid": "lockscreen@sri.ramkrishna.me", 


### PR DESCRIPTION
Since extensions website supporting major version recently,
we should only use "40" to avoid incompatibility for future minor release.