### PR TITLE
Add GNOME Shell 45-48 support

### DIFF
--- a/lockscreen@sri.ramkrishna.me/metadata.json
+++ b/lockscreen@sri.ramkrishna.me/metadata.json
@@ -2,7 +2,7 @@
   "description": "Add lock icon to the panel and lock the screen instead of using ctrl-alt-l", 
   "name": "Lock Screen", 
   "shell-version": [
-    "3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "40.0", "42.0", "43.0" ,"44.0", "45.0", "46.0", "47.0"
+    "45", "46", "47", "48"
   ], 
   "url": "https://github.com/sramkrishna/gnome3-extensions", 
   "uuid": "lockscreen@sri.ramkrishna.me", 


### PR DESCRIPTION
- Ported to ESM for compatibility with GNOME Shell 45+.
- Refactored lock screen button into its own class.
- Updated `metadata.json` to reflect support for GNOME Shell 45-48 and removed older, incompatible versions.
- Replaced `St.Bin` with `PanelMenu.Button` for consistent button styling.